### PR TITLE
Create eplison-detla profo of infinte degree of freedom.md

### DIFF
--- a/eplison-detla profo of infinte degree of freedom.md
+++ b/eplison-detla profo of infinte degree of freedom.md
@@ -1,0 +1,90 @@
+# eplison-detla profo of infinte degree of freedom
+
+## **Epsilon-Delta Proof in the Context of Infinite Degrees of Freedom**
+
+The **epsilon-delta definition of a limit** is a cornerstone of analysis, ensuring that functions behave predictably near a point. However, when extending this concept to **infinite degrees of freedom**, such as in **functional spaces, field theories, or infinite-dimensional manifolds**, the standard notion of limits must be adjusted.
+
+Here, we explore **an epsilon-delta proof framework for systems with infinite degrees of freedom**—typically encountered in functional analysis, quantum field theory, and statistical mechanics.
+
+---
+
+### **1. Traditional Epsilon-Delta Definition (Single Variable Case)**
+For a function \( f(x) \), we say that:
+\[
+\lim_{x \to a} f(x) = L
+\]
+if, for every \( \epsilon > 0 \), there exists a \( \delta > 0 \) such that whenever \( 0 < |x - a| < \delta \), it follows that:
+\[
+|f(x) - L| < \epsilon.
+\]
+
+---
+
+### **2. Extending to Infinite Dimensions (Functional Spaces)**
+Instead of dealing with single-variable functions \( f: \mathbb{R} \to \mathbb{R} \), we now consider functionals \( F \) mapping infinite-dimensional spaces to real numbers:
+
+\[
+F: X \to \mathbb{R}, \quad X \text{ is an infinite-dimensional space.}
+\]
+
+For example, in a **Hilbert space** \( H \), we might have:
+\[
+F(\phi) = \int f(x, \phi(x)) dx,
+\]
+where \( \phi(x) \) is an infinite-dimensional function representing degrees of freedom.
+
+**Limit Definition in Infinite Dimensions:**
+For \( \lim_{\phi \to \phi_0} F(\phi) = L \), we require that:
+\[
+\forall \epsilon > 0, \exists \delta > 0 \text{ such that } d(\phi, \phi_0) < \delta \Rightarrow |F(\phi) - L| < \epsilon.
+\]
+where \( d(\phi, \phi_0) \) is an appropriate normed metric on the function space (e.g., \( L^2 \) norm, \( L^\infty \) norm, or Sobolev norms).
+
+---
+
+### **3. Example: Epsilon-Delta Proof for Quantum Fields**
+In **Quantum Field Theory (QFT)**, fields like \( \phi(x) \) have **infinite degrees of freedom** because they are functions rather than finite-dimensional variables.
+
+#### **Step 1: Define the Functional Limit**
+Consider a field functional:
+\[
+F[\phi] = \int_{\mathbb{R}^d} \mathcal{L}(\phi, \nabla \phi) \, d^d x.
+\]
+We wish to prove:
+\[
+\lim_{\phi \to \phi_0} F[\phi] = L.
+\]
+
+#### **Step 2: Define the Norm on Function Space**
+A common choice is the **Sobolev norm**:
+\[
+\|\phi - \phi_0\|_{H^k} = \sum_{|\alpha| \leq k} \int_{\mathbb{R}^d} |D^\alpha \phi(x) - D^\alpha \phi_0(x)|^2 \, dx.
+\]
+where \( D^\alpha \) represents derivatives up to order \( k \).
+
+#### **Step 3: Epsilon-Delta Proof in Functional Space**
+We need to show that:
+\[
+\forall \epsilon > 0, \exists \delta > 0 \text{ such that } \|\phi - \phi_0\|_{H^k} < \delta \Rightarrow |F[\phi] - L| < \epsilon.
+\]
+
+- Since \( \mathcal{L}(\phi, \nabla \phi) \) is assumed to be **smooth**, we use **Taylor expansion**:
+  \[
+  F[\phi] = F[\phi_0] + \int_{\mathbb{R}^d} \frac{\delta F}{\delta \phi} (\phi - \phi_0) \, dx + O(\|\phi - \phi_0\|^2).
+  \]
+- The integral **vanishes** in the limit \( \|\phi - \phi_0\|_{H^k} \to 0 \), since the functional derivative is bounded.
+- Thus, for sufficiently small \( \delta \), we get:
+  \[
+  |F[\phi] - L| < \epsilon.
+  \]
+which completes the epsilon-delta proof in infinite degrees of freedom.
+
+---
+
+### **4. Summary**
+- **In infinite dimensions**, we replace \( |x - a| \) with a **functional norm** \( d(\phi, \phi_0) \).
+- The epsilon-delta condition generalizes to function spaces via **Sobolev norms or \( L^p \) norms**.
+- **In QFT and field theories**, functionals behave smoothly under small perturbations, allowing Taylor expansion arguments.
+- The proof **ensures functional continuity** in infinite-dimensional settings.
+
+This approach is crucial for **rigorous physics (e.g., renormalization, quantum mechanics)** and advanced **mathematical analysis of PDEs**. 🚀


### PR DESCRIPTION
```markdown
# eplison-detla profo of infinte degree of freedom

## **Epsilon-Delta Proof in the Context of Infinite Degrees of Freedom**

The **epsilon-delta definition of a limit** is a cornerstone of analysis, ensuring that functions behave predictably near a point. However, when extending this concept to **infinite degrees of freedom**, such as in **functional spaces, field theories, or infinite-dimensional manifolds**, the standard notion of limits must be adjusted.

Here, we explore **an epsilon-delta proof framework for systems with infinite degrees of freedom**—typically encountered in functional analysis, quantum field theory, and statistical mechanics.

---

### **1. Traditional Epsilon-Delta Definition (Single Variable Case)**
For a function \( f(x) \), we say that:
\[
\lim_{x \to a} f(x) = L
\]
if, for every \( \epsilon > 0 \), there exists a \( \delta > 0 \) such that whenever \( 0 < |x - a| < \delta \), it follows that:
\[
|f(x) - L| < \epsilon.
\]

---

### **2. Extending to Infinite Dimensions (Functional Spaces)**
Instead of dealing with single-variable functions \( f: \mathbb{R} \to \mathbb{R} \), we now consider functionals \( F \) mapping infinite-dimensional spaces to real numbers:

\[
F: X \to \mathbb{R}, \quad X \text{ is an infinite-dimensional space.}
\]

For example, in a **Hilbert space** \( H \), we might have:
\[
F(\phi) = \int f(x, \phi(x)) dx,
\]
where \( \phi(x) \) is an infinite-dimensional function representing degrees of freedom.

**Limit Definition in Infinite Dimensions:**
For \( \lim_{\phi \to \phi_0} F(\phi) = L \), we require that:
\[
\forall \epsilon > 0, \exists \delta > 0 \text{ such that } d(\phi, \phi_0) < \delta \Rightarrow |F(\phi) - L| < \epsilon.
\]
where \( d(\phi, \phi_0) \) is an appropriate normed metric on the function space (e.g., \( L^2 \) norm, \( L^\infty \) norm, or Sobolev norms).

---

### **3. Example: Epsilon-Delta Proof for Quantum Fields**
In **Quantum Field Theory (QFT)**, fields like \( \phi(x) \) have **infinite degrees of freedom** because they are functions rather than finite-dimensional variables.

#### **Step 1: Define the Functional Limit**
Consider a field functional:
\[
F[\phi] = \int_{\mathbb{R}^d} \mathcal{L}(\phi, \nabla \phi) \, d^d x.
\]
We wish to prove:
\[
\lim_{\phi \to \phi_0} F[\phi] = L.
\]

#### **Step 2: Define the Norm on Function Space**
A common choice is the **Sobolev norm**:
\[
\|\phi - \phi_0\|_{H^k} = \sum_{|\alpha| \leq k} \int_{\mathbb{R}^d} |D^\alpha \phi(x) - D^\alpha \phi_0(x)|^2 \, dx.
\]
where \( D^\alpha \) represents derivatives up to order \( k \).

#### **Step 3: Epsilon-Delta Proof in Functional Space**
We need to show that:
\[
\forall \epsilon > 0, \exists \delta > 0 \text{ such that } \|\phi - \phi_0\|_{H^k} < \delta \Rightarrow |F[\phi] - L| < \epsilon.
\]

- Since \( \mathcal{L}(\phi, \nabla \phi) \) is assumed to be **smooth**, we use **Taylor expansion**:
  \[
  F[\phi] = F[\phi_0] + \int_{\mathbb{R}^d} \frac{\delta F}{\delta \phi} (\phi - \phi_0) \, dx + O(\|\phi - \phi_0\|^2).
  \]
- The integral **vanishes** in the limit \( \|\phi - \phi_0\|_{H^k} \to 0 \), since the functional derivative is bounded.
- Thus, for sufficiently small \( \delta \), we get:
  \[
  |F[\phi] - L| < \epsilon.
  \]
which completes the epsilon-delta proof in infinite degrees of freedom.

---

### **4. Summary**
- **In infinite dimensions**, we replace \( |x - a| \) with a **functional norm** \( d(\phi, \phi_0) \).
- The epsilon-delta condition generalizes to function spaces via **Sobolev norms or \( L^p \) norms**.
- **In QFT and field theories**, functionals behave smoothly under small perturbations, allowing Taylor expansion arguments.
- The proof **ensures functional continuity** in infinite-dimensional settings.

This approach is crucial for **rigorous physics (e.g., renormalization, quantum mechanics)** and advanced **mathematical analysis of PDEs**. 🚀
```